### PR TITLE
Add `is_trial` flag to SKUs

### DIFF
--- a/configs/bundles.yml
+++ b/configs/bundles.yml
@@ -1,307 +1,600 @@
 - name: ansible
   skus:
-    - MCT3691
-    - MCT3691RN
-    - MCT3691F3
-    - MCT3691F3RN
-    - MCT3691S
-    - MCT3692
-    - MCT3692RN
-    - MCT3692F3
-    - MCT3692F3RN
-    - MCT3692S
-    - MCT3693
-    - MCT3693RN
-    - MCT3693F3
-    - MCT3693F3RN
-    - MCT3693S
-    - MCT3694
-    - MCT3694RN
-    - MCT3694F3
-    - MCT3694F3RN
-    - MCT3694S
-    - MCT3695
-    - MCT3695RN
-    - MCT3695F3
-    - MCT3695F3RN
-    - MCT3695S
-    - MCT3696
-    - MCT3696RN
-    - MCT3696F3
-    - MCT3696F3RN
-    - MCT3696S
-    - MCT3733
-    - MCT3733RN
-    - MCT3733F3
-    - MCT3733F3RN
-    - MCT3733S
-    - MCT3319
-    - MCT3319F3
-    - MCT3319RN
-    - MCT3319S
-    - MCT3320
-    - MCT3320F3
-    - MCT3320RN
-    - MCT3320S
-    - MCT3321
-    - MCT3321F3
-    - MCT3321RN
-    - MCT3321S
-    - MCT3742
-    - MCT3742F3
-    - MCT3742RN
-    - MCT3742S
-    - MCT3743
-    - MCT3743F3
-    - MCT3743RN
-    - MCT3743S
-    - MCT3744
-    - MCT3744F3
-    - MCT3744RN
-    - MCT3744S
-    - MCT3685
-    - MCT3685RN
-    - MCT3685F3
-    - MCT3685F3RN
-    - MCT3685S
-    - SER0496
-    - SER0496RN
-    - SER0496F3
-    - SER0496F3RN
-    - SER0496S
-    - SER0497
-    - SER0497RN
-    - SER0497F3
-    - SER0497F3RN
-    - SER0497S
-    - SER0569
-    - SER0569RN
-    - SER0569F3
-    - SER0569F3RN
-    - SER0569S
-    - SER0574
+    MCT3691:
+        is_trial: false
+    MCT3691RN:
+        is_trial: false
+    MCT3691F3:
+        is_trial: false
+    MCT3691F3RN:
+        is_trial: false
+    MCT3691S:
+        is_trial: false
+    MCT3692:
+        is_trial: false
+    MCT3692RN:
+        is_trial: false
+    MCT3692F3:
+        is_trial: false
+    MCT3692F3RN:
+        is_trial: false
+    MCT3692S:
+        is_trial: false
+    MCT3693:
+        is_trial: false
+    MCT3693RN:
+        is_trial: false
+    MCT3693F3:
+        is_trial: false
+    MCT3693F3RN:
+        is_trial: false
+    MCT3693S:
+        is_trial: false
+    MCT3694:
+        is_trial: false
+    MCT3694RN:
+        is_trial: false
+    MCT3694F3:
+        is_trial: false
+    MCT3694F3RN:
+        is_trial: false
+    MCT3694S:
+        is_trial: false
+    MCT3695:
+        is_trial: false
+    MCT3695RN:
+        is_trial: false
+    MCT3695F3:
+        is_trial: false
+    MCT3695F3RN:
+        is_trial: false
+    MCT3695S:
+        is_trial: false
+    MCT3696:
+        is_trial: false
+    MCT3696RN:
+        is_trial: false
+    MCT3696F3:
+        is_trial: false
+    MCT3696F3RN:
+        is_trial: false
+    MCT3696S:
+        is_trial: false
+    MCT3733:
+        is_trial: false
+    MCT3733RN:
+        is_trial: false
+    MCT3733F3:
+        is_trial: false
+    MCT3733F3RN:
+        is_trial: false
+    MCT3733S:
+        is_trial: false
+    MCT3319:
+        is_trial: false
+    MCT3319F3:
+        is_trial: false
+    MCT3319RN:
+        is_trial: false
+    MCT3319S:
+        is_trial: false
+    MCT3320:
+        is_trial: false
+    MCT3320F3:
+        is_trial: false
+    MCT3320RN:
+        is_trial: false
+    MCT3320S:
+        is_trial: false
+    MCT3321:
+        is_trial: false
+    MCT3321F3:
+        is_trial: false
+    MCT3321RN:
+        is_trial: false
+    MCT3321S:
+        is_trial: false
+    MCT3742:
+        is_trial: false
+    MCT3742F3:
+        is_trial: false
+    MCT3742RN:
+        is_trial: false
+    MCT3742S:
+        is_trial: false
+    MCT3743:
+        is_trial: false
+    MCT3743F3:
+        is_trial: false
+    MCT3743RN:
+        is_trial: false
+    MCT3743S:
+        is_trial: false
+    MCT3744:
+        is_trial: false
+    MCT3744F3:
+        is_trial: false
+    MCT3744RN:
+        is_trial: false
+    MCT3744S:
+        is_trial: false
+    MCT3685:
+        is_trial: false
+    MCT3685RN:
+        is_trial: false
+    MCT3685F3:
+        is_trial: false
+    MCT3685F3RN:
+        is_trial: false
+    MCT3685S:
+        is_trial: false
+    SER0496:
+        is_trial: false
+    SER0496RN:
+        is_trial: false
+    SER0496F3:
+        is_trial: false
+    SER0496F3RN:
+        is_trial: false
+    SER0496S:
+        is_trial: false
+    SER0497:
+        is_trial: false
+    SER0497RN:
+        is_trial: false
+    SER0497F3:
+        is_trial: false
+    SER0497F3RN:
+        is_trial: false
+    SER0497S:
+        is_trial: false
+    SER0569:
+        is_trial: false
+    SER0569RN:
+        is_trial: false
+    SER0569F3:
+        is_trial: false
+    SER0569F3RN:
+        is_trial: false
+    SER0569S:
+        is_trial: false
+    SER0574:
+        is_trial: false
 
 - name: cost_management
   skus:
-    - MW00454
-    - MW00455
-    - MW00456
-    - MW00457
-    - MW00458
-    - MW00459
-    - MW00448
-    - MW00449
-    - MW00450
-    - MW00451
-    - MW00452
-    - MW00453
-    - MW00373
-    - MW00374
-    - MW00375
-    - MW00376
-    - MW00377
-    - MW00378
-    - MW00361
-    - MW00362
-    - MW00363
-    - MW00364
-    - MW00365
-    - MW00366
-    - MCT2735
-    - MCT2736
-    - MCT3489
-    - MCT3490
-    - MCT3753
-    - MCT3754
-    - MCT3759
-    - MCT3760
-    - MW00329
-    - MW00330
-    - MW00331
-    - MW00332
-    - MW00421
-    - MW00422
-    - MCT2862
-    - MCT2863
+    MW00454:
+        is_trial: false
+    MW00455:
+        is_trial: false
+    MW00456:
+        is_trial: false
+    MW00457:
+        is_trial: false
+    MW00458:
+        is_trial: false
+    MW00459:
+        is_trial: false
+    MW00448:
+        is_trial: false
+    MW00449:
+        is_trial: false
+    MW00450:
+        is_trial: false
+    MW00451:
+        is_trial: false
+    MW00452:
+        is_trial: false
+    MW00453:
+        is_trial: false
+    MW00373:
+        is_trial: false
+    MW00374:
+        is_trial: false
+    MW00375:
+        is_trial: false
+    MW00376:
+        is_trial: false
+    MW00377:
+        is_trial: false
+    MW00378:
+        is_trial: false
+    MW00361:
+        is_trial: false
+    MW00362:
+        is_trial: false
+    MW00363:
+        is_trial: false
+    MW00364:
+        is_trial: false
+    MW00365:
+        is_trial: false
+    MW00366:
+        is_trial: false
+    MCT2735:
+        is_trial: false
+    MCT2736:
+        is_trial: false
+    MCT3489:
+        is_trial: false
+    MCT3490:
+        is_trial: false
+    MCT3753:
+        is_trial: false
+    MCT3754:
+        is_trial: false
+    MCT3759:
+        is_trial: false
+    MCT3760:
+        is_trial: false
+    MW00329:
+        is_trial: false
+    MW00330:
+        is_trial: false
+    MW00331:
+        is_trial: false
+    MW00332:
+        is_trial: false
+    MW00421:
+        is_trial: false
+    MW00422:
+        is_trial: false
+    MCT2862:
+        is_trial: false
+    MCT2863:
+        is_trial: false
 
 - name: insights
   use_valid_acc_num: true
 
 - name: migrations
   skus:
-    - SER0584
-    - CL216
-    - CL216OS
-    - CL216VT
-    - CL218
-    - CL218IGE
-    - CL218OS
-    - CL218PT
-    - CL218VT
-    - CL220
-    - CL220IGE
-    - CL220IGE-R1
-    - CL220IGE-R2
-    - CL220IGE-R3
-    - CL220OS
-    - CL220VC
-    - ESA0017
-    - ESA0039
-    - MCT2358
-    - MCT2358F3
-    - MCT2358F3RN
-    - MCT2358RN
-    - MCT2360
-    - MCT2360F3
-    - MCT2360F3RN
-    - MCT2360RN
-    - MCT2834
-    - MCT2838
-    - MCT2838F3
-    - MCT2838F3RN
-    - MCT2838RN
-    - MCT2838S
-    - MCT2839
-    - MCT2839F3
-    - MCT2839F3RN
-    - MCT2839RN
-    - MCT2840
-    - MCT2840F3
-    - MCT2840F3RN
-    - MCT2840RN
-    - MCT2841
-    - MCT2841F3
-    - MCT2841F3RN
-    - MCT2841RN
-    - MCT2841S
-    - MCT2842
-    - MCT2842F3
-    - MCT2842F3RN
-    - MCT2842RN
-    - MCT2843
-    - MCT2843F3
-    - MCT2843F3RN
-    - MCT2843RN
-    - MCT2856
-    - MCT2856F3
-    - MCT2856F3RN
-    - MCT2856RN
-    - MCT2856S
-    - MCT2955
-    - MCT3116
-    - MCT3158
-    - MCT3159
-    - MCT3867
-    - MCT3868
-    - PT208
-    - RH00541
-    - RH00541F3
-    - RH00541F3RN
-    - RH00541RN
-    - RH00541S
-    - RH00542
-    - RH00542F3
-    - RH00542F3RN
-    - RH00542RN
-    - RH00542S
-    - RH00543
-    - RH00543F3
-    - RH00543F3RN
-    - RH00543RN
-    - RH00543S
-    - RH00544
-    - RH00544F3
-    - RH00544F3RN
-    - RH00544RN
-    - RH00544S
-    - RV00062
-    - RV00062F3
-    - RV00062F3RN
-    - RV00062RN
-    - RV00062S
-    - RV00063
-    - RV00063F3
-    - RV00063F3RN
-    - RV00063RN
-    - RV00063S
-    - RV00064
-    - RV00064F3
-    - RV00064F3RN
-    - RV00064RN
-    - RV00064S
-    - SER0407
-    - SER0408
-    - SER0412
-    - SER0430
-    - SER0431
-    - SER0432
-    - SER0433
-    - SER0442
-    - SER0583
-    - SER0584
-    - SVC1356
-    - SVC1358
-    - SVC1396
-    - SVC1885
-    - SVC1936
-    - SVC1937
-    - SVC1938
-    - SVC1939
-    - SVC1940
-    - SVC1941
-    - SVC1942
-    - SVC1943
-    - SVC1944
-    - SVC1945
-    - SVC1958
-    - SVC1974
-    - SVC2058
-    - SVC2059
-    - SVC2450
-    - SVC2492
-    - SVC2493
-    - SVC3867
-    - SVC3868
-    - SVCCL220VC
-    - SVCESA0017
-    - SVCESA0039
-    - SVCRH00541
-    - SVCRH00542
-    - SVCRH00543
-    - SVCRH00544
-    - SVCRV00062
-    - SVCRV00063
-    - SVCRV00064
-    - SVCSER0583
-    - SVCSER0584
-    - SYS1356
-    - SYS1358
-    - SYS1396
-    - SYS1885
-    - SYS1936
-    - SYS1937
-    - SYS1938
-    - SYS1939
-    - SYS1940
-    - SYS1941
-    - SYS1942
-    - SYS1943
-    - SYS1944
-    - SYS1945
-    - SYS1958
-    - SYS1974
-    - SYS2058
-    - SYS2059
-    - SYS2450
-    - SYS2492
-    - SYS2493
-    - TRK216
-    - TRK218
-    - TRK218IG
-    - TRK220
-    - TRK220IG
-    - TRK220IG-R4
-    - TRK220IG-R5
+    SER0584:
+        is_trial: false
+    CL216:
+        is_trial: false
+    CL216OS:
+        is_trial: false
+    CL216VT:
+        is_trial: false
+    CL218:
+        is_trial: false
+    CL218IGE:
+        is_trial: false
+    CL218OS:
+        is_trial: false
+    CL218PT:
+        is_trial: false
+    CL218VT:
+        is_trial: false
+    CL220:
+        is_trial: false
+    CL220IGE:
+        is_trial: false
+    CL220IGE-R1:
+        is_trial: false
+    CL220IGE-R2:
+        is_trial: false
+    CL220IGE-R3:
+        is_trial: false
+    CL220OS:
+        is_trial: false
+    CL220VC:
+        is_trial: false
+    ESA0017:
+        is_trial: false
+    ESA0039:
+        is_trial: false
+    MCT2358:
+        is_trial: false
+    MCT2358F3:
+        is_trial: false
+    MCT2358F3RN:
+        is_trial: false
+    MCT2358RN:
+        is_trial: false
+    MCT2360:
+        is_trial: false
+    MCT2360F3:
+        is_trial: false
+    MCT2360F3RN:
+        is_trial: false
+    MCT2360RN:
+        is_trial: false
+    MCT2834:
+        is_trial: false
+    MCT2838:
+        is_trial: false
+    MCT2838F3:
+        is_trial: false
+    MCT2838F3RN:
+        is_trial: false
+    MCT2838RN:
+        is_trial: false
+    MCT2838S:
+        is_trial: false
+    MCT2839:
+        is_trial: false
+    MCT2839F3:
+        is_trial: false
+    MCT2839F3RN:
+        is_trial: false
+    MCT2839RN:
+        is_trial: false
+    MCT2840:
+        is_trial: false
+    MCT2840F3:
+        is_trial: false
+    MCT2840F3RN:
+        is_trial: false
+    MCT2840RN:
+        is_trial: false
+    MCT2841:
+        is_trial: false
+    MCT2841F3:
+        is_trial: false
+    MCT2841F3RN:
+        is_trial: false
+    MCT2841RN:
+        is_trial: false
+    MCT2841S:
+        is_trial: false
+    MCT2842:
+        is_trial: false
+    MCT2842F3:
+        is_trial: false
+    MCT2842F3RN:
+        is_trial: false
+    MCT2842RN:
+        is_trial: false
+    MCT2843:
+        is_trial: false
+    MCT2843F3:
+        is_trial: false
+    MCT2843F3RN:
+        is_trial: false
+    MCT2843RN:
+        is_trial: false
+    MCT2856:
+        is_trial: false
+    MCT2856F3:
+        is_trial: false
+    MCT2856F3RN:
+        is_trial: false
+    MCT2856RN:
+        is_trial: false
+    MCT2856S:
+        is_trial: false
+    MCT2955:
+        is_trial: false
+    MCT3116:
+        is_trial: false
+    MCT3158:
+        is_trial: false
+    MCT3159:
+        is_trial: false
+    MCT3867:
+        is_trial: false
+    MCT3868:
+        is_trial: false
+    PT208:
+        is_trial: false
+    RH00541:
+        is_trial: false
+    RH00541F3:
+        is_trial: false
+    RH00541F3RN:
+        is_trial: false
+    RH00541RN:
+        is_trial: false
+    RH00541S:
+        is_trial: false
+    RH00542:
+        is_trial: false
+    RH00542F3:
+        is_trial: false
+    RH00542F3RN:
+        is_trial: false
+    RH00542RN:
+        is_trial: false
+    RH00542S:
+        is_trial: false
+    RH00543:
+        is_trial: false
+    RH00543F3:
+        is_trial: false
+    RH00543F3RN:
+        is_trial: false
+    RH00543RN:
+        is_trial: false
+    RH00543S:
+        is_trial: false
+    RH00544:
+        is_trial: false
+    RH00544F3:
+        is_trial: false
+    RH00544F3RN:
+        is_trial: false
+    RH00544RN:
+        is_trial: false
+    RH00544S:
+        is_trial: false
+    RV00062:
+        is_trial: false
+    RV00062F3:
+        is_trial: false
+    RV00062F3RN:
+        is_trial: false
+    RV00062RN:
+        is_trial: false
+    RV00062S:
+        is_trial: false
+    RV00063:
+        is_trial: false
+    RV00063F3:
+        is_trial: false
+    RV00063F3RN:
+        is_trial: false
+    RV00063RN:
+        is_trial: false
+    RV00063S:
+        is_trial: false
+    RV00064:
+        is_trial: false
+    RV00064F3:
+        is_trial: false
+    RV00064F3RN:
+        is_trial: false
+    RV00064RN:
+        is_trial: false
+    RV00064S:
+        is_trial: false
+    SER0407:
+        is_trial: false
+    SER0408:
+        is_trial: false
+    SER0412:
+        is_trial: false
+    SER0430:
+        is_trial: false
+    SER0431:
+        is_trial: false
+    SER0432:
+        is_trial: false
+    SER0433:
+        is_trial: false
+    SER0442:
+        is_trial: false
+    SER0583:
+        is_trial: false
+    SER0584:
+        is_trial: false
+    SVC1356:
+        is_trial: false
+    SVC1358:
+        is_trial: false
+    SVC1396:
+        is_trial: false
+    SVC1885:
+        is_trial: false
+    SVC1936:
+        is_trial: false
+    SVC1937:
+        is_trial: false
+    SVC1938:
+        is_trial: false
+    SVC1939:
+        is_trial: false
+    SVC1940:
+        is_trial: false
+    SVC1941:
+        is_trial: false
+    SVC1942:
+        is_trial: false
+    SVC1943:
+        is_trial: false
+    SVC1944:
+        is_trial: false
+    SVC1945:
+        is_trial: false
+    SVC1958:
+        is_trial: false
+    SVC1974:
+        is_trial: false
+    SVC2058:
+        is_trial: false
+    SVC2059:
+        is_trial: false
+    SVC2450:
+        is_trial: false
+    SVC2492:
+        is_trial: false
+    SVC2493:
+        is_trial: false
+    SVC3867:
+        is_trial: false
+    SVC3868:
+        is_trial: false
+    SVCCL220VC:
+        is_trial: false
+    SVCESA0017:
+        is_trial: false
+    SVCESA0039:
+        is_trial: false
+    SVCRH00541:
+        is_trial: false
+    SVCRH00542:
+        is_trial: false
+    SVCRH00543:
+        is_trial: false
+    SVCRH00544:
+        is_trial: false
+    SVCRV00062:
+        is_trial: false
+    SVCRV00063:
+        is_trial: false
+    SVCRV00064:
+        is_trial: false
+    SVCSER0583:
+        is_trial: false
+    SVCSER0584:
+        is_trial: false
+    SYS1356:
+        is_trial: false
+    SYS1358:
+        is_trial: false
+    SYS1396:
+        is_trial: false
+    SYS1885:
+        is_trial: false
+    SYS1936:
+        is_trial: false
+    SYS1937:
+        is_trial: false
+    SYS1938:
+        is_trial: false
+    SYS1939:
+        is_trial: false
+    SYS1940:
+        is_trial: false
+    SYS1941:
+        is_trial: false
+    SYS1942:
+        is_trial: false
+    SYS1943:
+        is_trial: false
+    SYS1944:
+        is_trial: false
+    SYS1945:
+        is_trial: false
+    SYS1958:
+        is_trial: false
+    SYS1974:
+        is_trial: false
+    SYS2058:
+        is_trial: false
+    SYS2059:
+        is_trial: false
+    SYS2450:
+        is_trial: false
+    SYS2492:
+        is_trial: false
+    SYS2493:
+        is_trial: false
+    TRK216:
+        is_trial: false
+    TRK218:
+        is_trial: false
+    TRK218IG:
+        is_trial: false
+    TRK220:
+        is_trial: false
+    TRK220IG:
+        is_trial: false
+    TRK220IG-R4:
+        is_trial: false
+    TRK220IG-R5:
+        is_trial: false
 
 - name: subscriptions
   use_valid_acc_num: true
@@ -314,6 +607,9 @@
 
 - name: smart_management
   skus:
-    - SVC3124
-    - RH00066
-    - RH00065
+    SVC3124:
+        is_trial: false
+    RH00066:
+        is_trial: false
+    RH00065:
+        is_trial: false


### PR DESCRIPTION
This is a supportive, prerequisite PR for https://github.com/RedHatInsights/entitlements-api-go/pull/50

Any SKUs which should be treated as trial SKUs will need to have `is_trial` set
to `true`.