### PR TITLE
fix(bundles): remove duplicate entry

### DIFF
--- a/configs/bundles.yml
+++ b/configs/bundles.yml
@@ -246,8 +246,6 @@
         is_trial: false
     MCT3815F3RN:
         is_trial: false
-    MCT3815S:
-        is_trial: false
     MCT3816:
         is_trial: false
     MCT3816RN:


### PR DESCRIPTION
My YAML parser isn't too happy:
```
insights-standalone/node_modules/js-yaml/lib/loader.js:187
  throw generateError(state, message);
  ^
YAMLException: duplicated mapping key (249:5)

 246 |         is_trial: false
 247 |     MCT3815F3RN:
 248 |         is_trial: false
 249 |     MCT3815S:
-----------^
 250 |         is_trial: false
 251 |     MCT3816:
```