### PR TITLE
Remove `is_trial` flag from config

### DIFF
--- a/configs/fedramp-prod/bundles.yml
+++ b/configs/fedramp-prod/bundles.yml
@@ -6,440 +6,223 @@ objects:
     bundles.yml: |
       - name: ansible
         skus:
-          RH00798:
-              is_trial: false
-          ESA0016:
-              is_trial: false
-          MCT3319:
-              is_trial: false
-          MCT3319F3:
-              is_trial: false
-          MCT3319RN:
-              is_trial: false
-          MCT3319S:
-              is_trial: false
-          MCT3320:
-              is_trial: false
-          MCT3320F3:
-              is_trial: false
-          MCT3320RN:
-              is_trial: false
-          MCT3320S:
-              is_trial: false
-          MCT3321:
-              is_trial: false
-          MCT3321F3:
-              is_trial: false
-          MCT3321RN:
-              is_trial: false
-          MCT3321S:
-              is_trial: false
-          MCT3487:
-              is_trial: false
-          MCT3487F3:
-              is_trial: false
-          MCT3487RN:
-              is_trial: false
-          MCT3487S:
-              is_trial: false
-          MCT3488:
-              is_trial: false
-          MCT3488F3:
-              is_trial: false
-          MCT3488RN:
-              is_trial: false
-          MCT3488S:
-              is_trial: false
-          MCT3685:
-              is_trial: false
-          MCT3685RN:
-              is_trial: false
-          MCT3685F3:
-              is_trial: false
-          MCT3685F3RN:
-              is_trial: false
-          MCT3685S:
-              is_trial: false
-          MCT3691:
-              is_trial: false
-          MCT3691RN:
-              is_trial: false
-          MCT3691F3:
-              is_trial: false
-          MCT3691F3RN:
-              is_trial: false
-          MCT3691S:
-              is_trial: false
-          MCT3692:
-              is_trial: false
-          MCT3692RN:
-              is_trial: false
-          MCT3692F3:
-              is_trial: false
-          MCT3692F3RN:
-              is_trial: false
-          MCT3692S:
-              is_trial: false
-          MCT3693:
-              is_trial: false
-          MCT3693RN:
-              is_trial: false
-          MCT3693F3:
-              is_trial: false
-          MCT3693F3RN:
-              is_trial: false
-          MCT3693S:
-              is_trial: false
-          MCT3694:
-              is_trial: false
-          MCT3694RN:
-              is_trial: false
-          MCT3694F3:
-              is_trial: false
-          MCT3694F3RN:
-              is_trial: false
-          MCT3694S:
-              is_trial: false
-          MCT3695:
-              is_trial: false
-          MCT3695RN:
-              is_trial: false
-          MCT3695F3:
-              is_trial: false
-          MCT3695F3RN:
-              is_trial: false
-          MCT3695S:
-              is_trial: false
-          MCT3696:
-              is_trial: false
-          MCT3696RN:
-              is_trial: false
-          MCT3696F3:
-              is_trial: false
-          MCT3696F3RN:
-              is_trial: false
-          MCT3696S:
-              is_trial: false
-          MCT3698:
-              is_trial: false
-          MCT3698RN:
-              is_trial: false
-          MCT3698F3:
-              is_trial: false
-          MCT3698F3RN:
-              is_trial: false
-          MCT3698S:
-              is_trial: false
-          MCT3733:
-              is_trial: false
-          MCT3733RN:
-              is_trial: false
-          MCT3733F3:
-              is_trial: false
-          MCT3733F3RN:
-              is_trial: false
-          MCT3733S:
-              is_trial: false
-          MCT3734:
-              is_trial: false
-          MCT3734RN:
-              is_trial: false
-          MCT3734F3:
-              is_trial: false
-          MCT3734F3RN:
-              is_trial: false
-          MCT3734S:
-              is_trial: false
-          MCT3735:
-              is_trial: false
-          MCT3735RN:
-              is_trial: false
-          MCT3735F3:
-              is_trial: false
-          MCT3735F3RN:
-              is_trial: false
-          MCT3735S:
-              is_trial: false
-          MCT3742:
-              is_trial: false
-          MCT3742F3:
-              is_trial: false
-          MCT3742RN:
-              is_trial: false
-          MCT3742S:
-              is_trial: false
-          MCT3743:
-              is_trial: false
-          MCT3743F3:
-              is_trial: false
-          MCT3743RN:
-              is_trial: false
-          MCT3743S:
-              is_trial: false
-          MCT3744:
-              is_trial: false
-          MCT3744F3:
-              is_trial: false
-          MCT3744RN:
-              is_trial: false
-          MCT3744S:
-              is_trial: false
-          MCT3809:
-              is_trial: false
-          MCT3809RN:
-              is_trial: false
-          MCT3809F3:
-              is_trial: false
-          MCT3809F3RN:
-              is_trial: false
-          MCT3809S:
-              is_trial: false
-          MCT3810:
-              is_trial: false
-          MCT3810RN:
-              is_trial: false
-          MCT3810F3:
-              is_trial: false
-          MCT3810F3RN:
-              is_trial: false
-          MCT3810S:
-              is_trial: false
-          MCT3811:
-              is_trial: false
-          MCT3811RN:
-              is_trial: false
-          MCT3811F3:
-              is_trial: false
-          MCT3811F3RN:
-              is_trial: false
-          MCT3811S:
-              is_trial: false
-          MCT3812:
-              is_trial: false
-          MCT3812RN:
-              is_trial: false
-          MCT3812F3:
-              is_trial: false
-          MCT3812F3RN:
-              is_trial: false
-          MCT3812S:
-              is_trial: false
-          MCT3813:
-              is_trial: false
-          MCT3813RN:
-              is_trial: false
-          MCT3813F3:
-              is_trial: false
-          MCT3813F3RN:
-              is_trial: false
-          MCT3813S:
-              is_trial: false
-          MCT3814:
-              is_trial: false
-          MCT3814RN:
-              is_trial: false
-          MCT3814F3:
-              is_trial: false
-          MCT3814F3RN:
-              is_trial: false
-          MCT3815S:
-              is_trial: false
-          MCT3815:
-              is_trial: false
-          MCT3815RN:
-              is_trial: false
-          MCT3815F3:
-              is_trial: false
-          MCT3815F3RN:
-              is_trial: false
-          MCT3816:
-              is_trial: false
-          MCT3816RN:
-              is_trial: false
-          MCT3816F3:
-              is_trial: false
-          MCT3816F3RN:
-              is_trial: false
-          MCT3816S:
-              is_trial: false
-          MCT3817:
-              is_trial: false
-          MCT3817RN:
-              is_trial: false
-          MCT3817F3:
-              is_trial: false
-          MCT3817F3RN:
-              is_trial: false
-          MCT3817S:
-              is_trial: false
-          MCT3865:
-              is_trial: false
-          MCT3865RN:
-              is_trial: false
-          MCT3865F3:
-              is_trial: false
-          MCT3865F3RN:
-              is_trial: false
-          MCT3865S:
-              is_trial: false
-          MCT3866:
-              is_trial: false
-          MCT3866RN:
-              is_trial: false
-          MCT3866F3:
-              is_trial: false
-          MCT3866F3RN:
-              is_trial: false
-          MCT3866S:
-              is_trial: false
-          MCT3873:
-              is_trial: false
-          MCT3873RN:
-              is_trial: false
-          MCT3873F3:
-              is_trial: false
-          MCT3873F3RN:
-              is_trial: false
-          MCT3873S:
-              is_trial: false
-          MCT3874:
-              is_trial: false
-          MCT3874RN:
-              is_trial: false
-          MCT3874F3:
-              is_trial: false
-          MCT3874F3RN:
-              is_trial: false
-          MCT3874S:
-              is_trial: false
-          MCT3875:
-              is_trial: false
-          MCT3875RN:
-              is_trial: false
-          MCT3875F3:
-              is_trial: false
-          MCT3875F3RN:
-              is_trial: false
-          MCT3875S:
-              is_trial: false
-          MCT3876:
-              is_trial: false
-          MCT3876RN:
-              is_trial: false
-          MCT3876F3:
-              is_trial: false
-          MCT3876F3RN:
-              is_trial: false
-          MCT3876S:
-              is_trial: false
-          MCT3877:
-              is_trial: false
-          MCT3877RN:
-              is_trial: false
-          MCT3877F3:
-              is_trial: false
-          MCT3877F3RN:
-              is_trial: false
-          MCT3877S:
-              is_trial: false
-          MCT3878:
-              is_trial: false
-          MCT3878RN:
-              is_trial: false
-          MCT3878F3:
-              is_trial: false
-          MCT3878F3RN:
-              is_trial: false
-          MCT3878S:
-              is_trial: false
-          MCT3906:
-              is_trial: false
-          MCT3906RN:
-              is_trial: false
-          MCT3906F3:
-              is_trial: false
-          MCT3906F3RN:
-              is_trial: false
-          MCT3906S:
-              is_trial: false
-          MCT3907:
-              is_trial: false
-          MCT3907RN:
-              is_trial: false
-          MCT3907F3:
-              is_trial: false
-          MCT3907F3RN:
-              is_trial: false
-          MCT3907S:
-              is_trial: false
-          MCT3908:
-              is_trial: false
-          MCT3908RN:
-              is_trial: false
-          MCT3908F3:
-              is_trial: false
-          MCT3908F3RN:
-              is_trial: false
-          MCT3908S:
-              is_trial: false
-          MCT3909:
-              is_trial: false
-          MCT3909RN:
-              is_trial: false
-          MCT3909F3:
-              is_trial: false
-          MCT3909F3RN:
-              is_trial: false
-          MCT3909S:
-              is_trial: false
-          MCT3910:
-              is_trial: false
-          MCT3910RN:
-              is_trial: false
-          MCT3910F3:
-              is_trial: false
-          MCT3910F3RN:
-              is_trial: false
-          MCT3910S:
-              is_trial: false
-          MCT3911:
-              is_trial: false
-          MCT3911RN:
-              is_trial: false
-          MCT3911F3:
-              is_trial: false
-          MCT3911F3RN:
-              is_trial: false
-          MCT3911S:
-              is_trial: false
-          MCT3948:
-              is_trial: false
-          MW01459:
-              is_trial: false
-          MW01460:
-              is_trial: false
-          MW01461:
-              is_trial: false
-          MW01462:
-              is_trial: false
-          MW01737:
-              is_trial: false
-          MW01882:
-              is_trial: false
-          MW01891:
-              is_trial: false
-          MW01892MO:
-              is_trial: false
-          SER0496:
-              is_trial: true
-          SER0497:
-              is_trial: true
-          SER0569:
-              is_trial: true
-          SER0570:
-              is_trial: true
-          SER0574:
-              is_trial: true
+          - RH00798
+          - ESA0016
+          - MCT3319
+          - MCT3319F3
+          - MCT3319RN
+          - MCT3319S
+          - MCT3320
+          - MCT3320F3
+          - MCT3320RN
+          - MCT3320S
+          - MCT3321
+          - MCT3321F3
+          - MCT3321RN
+          - MCT3321S
+          - MCT3487
+          - MCT3487F3
+          - MCT3487RN
+          - MCT3487S
+          - MCT3488
+          - MCT3488F3
+          - MCT3488RN
+          - MCT3488S
+          - MCT3685
+          - MCT3685RN
+          - MCT3685F3
+          - MCT3685F3RN
+          - MCT3685S
+          - MCT3691
+          - MCT3691RN
+          - MCT3691F3
+          - MCT3691F3RN
+          - MCT3691S
+          - MCT3692
+          - MCT3692RN
+          - MCT3692F3
+          - MCT3692F3RN
+          - MCT3692S
+          - MCT3693
+          - MCT3693RN
+          - MCT3693F3
+          - MCT3693F3RN
+          - MCT3693S
+          - MCT3694
+          - MCT3694RN
+          - MCT3694F3
+          - MCT3694F3RN
+          - MCT3694S
+          - MCT3695
+          - MCT3695RN
+          - MCT3695F3
+          - MCT3695F3RN
+          - MCT3695S
+          - MCT3696
+          - MCT3696RN
+          - MCT3696F3
+          - MCT3696F3RN
+          - MCT3696S
+          - MCT3698
+          - MCT3698RN
+          - MCT3698F3
+          - MCT3698F3RN
+          - MCT3698S
+          - MCT3733
+          - MCT3733RN
+          - MCT3733F3
+          - MCT3733F3RN
+          - MCT3733S
+          - MCT3734
+          - MCT3734RN
+          - MCT3734F3
+          - MCT3734F3RN
+          - MCT3734S
+          - MCT3735
+          - MCT3735RN
+          - MCT3735F3
+          - MCT3735F3RN
+          - MCT3735S
+          - MCT3742
+          - MCT3742F3
+          - MCT3742RN
+          - MCT3742S
+          - MCT3743
+          - MCT3743F3
+          - MCT3743RN
+          - MCT3743S
+          - MCT3744
+          - MCT3744F3
+          - MCT3744RN
+          - MCT3744S
+          - MCT3809
+          - MCT3809RN
+          - MCT3809F3
+          - MCT3809F3RN
+          - MCT3809S
+          - MCT3810
+          - MCT3810RN
+          - MCT3810F3
+          - MCT3810F3RN
+          - MCT3810S
+          - MCT3811
+          - MCT3811RN
+          - MCT3811F3
+          - MCT3811F3RN
+          - MCT3811S
+          - MCT3812
+          - MCT3812RN
+          - MCT3812F3
+          - MCT3812F3RN
+          - MCT3812S
+          - MCT3813
+          - MCT3813RN
+          - MCT3813F3
+          - MCT3813F3RN
+          - MCT3813S
+          - MCT3814
+          - MCT3814RN
+          - MCT3814F3
+          - MCT3814F3RN
+          - MCT3815S
+          - MCT3815
+          - MCT3815RN
+          - MCT3815F3
+          - MCT3815F3RN
+          - MCT3816
+          - MCT3816RN
+          - MCT3816F3
+          - MCT3816F3RN
+          - MCT3816S
+          - MCT3817
+          - MCT3817RN
+          - MCT3817F3
+          - MCT3817F3RN
+          - MCT3817S
+          - MCT3865
+          - MCT3865RN
+          - MCT3865F3
+          - MCT3865F3RN
+          - MCT3865S
+          - MCT3866
+          - MCT3866RN
+          - MCT3866F3
+          - MCT3866F3RN
+          - MCT3866S
+          - MCT3873
+          - MCT3873RN
+          - MCT3873F3
+          - MCT3873F3RN
+          - MCT3873S
+          - MCT3874
+          - MCT3874RN
+          - MCT3874F3
+          - MCT3874F3RN
+          - MCT3874S
+          - MCT3875
+          - MCT3875RN
+          - MCT3875F3
+          - MCT3875F3RN
+          - MCT3875S
+          - MCT3876
+          - MCT3876RN
+          - MCT3876F3
+          - MCT3876F3RN
+          - MCT3876S
+          - MCT3877
+          - MCT3877RN
+          - MCT3877F3
+          - MCT3877F3RN
+          - MCT3877S
+          - MCT3878
+          - MCT3878RN
+          - MCT3878F3
+          - MCT3878F3RN
+          - MCT3878S
+          - MCT3906
+          - MCT3906RN
+          - MCT3906F3
+          - MCT3906F3RN
+          - MCT3906S
+          - MCT3907
+          - MCT3907RN
+          - MCT3907F3
+          - MCT3907F3RN
+          - MCT3907S
+          - MCT3908
+          - MCT3908RN
+          - MCT3908F3
+          - MCT3908F3RN
+          - MCT3908S
+          - MCT3909
+          - MCT3909RN
+          - MCT3909F3
+          - MCT3909F3RN
+          - MCT3909S
+          - MCT3910
+          - MCT3910RN
+          - MCT3910F3
+          - MCT3910F3RN
+          - MCT3910S
+          - MCT3911
+          - MCT3911RN
+          - MCT3911F3
+          - MCT3911F3RN
+          - MCT3911S
+          - MCT3948
+          - MW01459
+          - MW01460
+          - MW01461
+          - MW01462
+          - MW01737
+          - MW01882
+          - MW01891
+          - MW01892MO
+          - SER0496
+          - SER0497
+          - SER0569
+          - SER0570
+          - SER0574
 
       - name: cost_management
         use_valid_acc_num: true
@@ -464,18 +247,14 @@ objects:
 
       - name: smart_management
         skus:
-          SVC3124:
-              is_trial: false
-          RH00066:
-              is_trial: true
-          RH00065:
-              is_trial: true
-          RH00798:
-              is_trial: false
+          - SVC3124
+          - RH00066
+          - RH00065
+          - RH00798
 
       - name: internal
         use_is_internal: true
-        
+
       - name: rhel
         use_valid_acc_num: true
   kind: ConfigMap

--- a/configs/fedramp-stage/bundles.yml
+++ b/configs/fedramp-stage/bundles.yml
@@ -6,440 +6,223 @@ objects:
     bundles.yml: |
       - name: ansible
         skus:
-          RH00798:
-              is_trial: false
-          ESA0016:
-              is_trial: false
-          MCT3319:
-              is_trial: false
-          MCT3319F3:
-              is_trial: false
-          MCT3319RN:
-              is_trial: false
-          MCT3319S:
-              is_trial: false
-          MCT3320:
-              is_trial: false
-          MCT3320F3:
-              is_trial: false
-          MCT3320RN:
-              is_trial: false
-          MCT3320S:
-              is_trial: false
-          MCT3321:
-              is_trial: false
-          MCT3321F3:
-              is_trial: false
-          MCT3321RN:
-              is_trial: false
-          MCT3321S:
-              is_trial: false
-          MCT3487:
-              is_trial: false
-          MCT3487F3:
-              is_trial: false
-          MCT3487RN:
-              is_trial: false
-          MCT3487S:
-              is_trial: false
-          MCT3488:
-              is_trial: false
-          MCT3488F3:
-              is_trial: false
-          MCT3488RN:
-              is_trial: false
-          MCT3488S:
-              is_trial: false
-          MCT3685:
-              is_trial: false
-          MCT3685RN:
-              is_trial: false
-          MCT3685F3:
-              is_trial: false
-          MCT3685F3RN:
-              is_trial: false
-          MCT3685S:
-              is_trial: false
-          MCT3691:
-              is_trial: false
-          MCT3691RN:
-              is_trial: false
-          MCT3691F3:
-              is_trial: false
-          MCT3691F3RN:
-              is_trial: false
-          MCT3691S:
-              is_trial: false
-          MCT3692:
-              is_trial: false
-          MCT3692RN:
-              is_trial: false
-          MCT3692F3:
-              is_trial: false
-          MCT3692F3RN:
-              is_trial: false
-          MCT3692S:
-              is_trial: false
-          MCT3693:
-              is_trial: false
-          MCT3693RN:
-              is_trial: false
-          MCT3693F3:
-              is_trial: false
-          MCT3693F3RN:
-              is_trial: false
-          MCT3693S:
-              is_trial: false
-          MCT3694:
-              is_trial: false
-          MCT3694RN:
-              is_trial: false
-          MCT3694F3:
-              is_trial: false
-          MCT3694F3RN:
-              is_trial: false
-          MCT3694S:
-              is_trial: false
-          MCT3695:
-              is_trial: false
-          MCT3695RN:
-              is_trial: false
-          MCT3695F3:
-              is_trial: false
-          MCT3695F3RN:
-              is_trial: false
-          MCT3695S:
-              is_trial: false
-          MCT3696:
-              is_trial: false
-          MCT3696RN:
-              is_trial: false
-          MCT3696F3:
-              is_trial: false
-          MCT3696F3RN:
-              is_trial: false
-          MCT3696S:
-              is_trial: false
-          MCT3698:
-              is_trial: false
-          MCT3698RN:
-              is_trial: false
-          MCT3698F3:
-              is_trial: false
-          MCT3698F3RN:
-              is_trial: false
-          MCT3698S:
-              is_trial: false
-          MCT3733:
-              is_trial: false
-          MCT3733RN:
-              is_trial: false
-          MCT3733F3:
-              is_trial: false
-          MCT3733F3RN:
-              is_trial: false
-          MCT3733S:
-              is_trial: false
-          MCT3734:
-              is_trial: false
-          MCT3734RN:
-              is_trial: false
-          MCT3734F3:
-              is_trial: false
-          MCT3734F3RN:
-              is_trial: false
-          MCT3734S:
-              is_trial: false
-          MCT3735:
-              is_trial: false
-          MCT3735RN:
-              is_trial: false
-          MCT3735F3:
-              is_trial: false
-          MCT3735F3RN:
-              is_trial: false
-          MCT3735S:
-              is_trial: false
-          MCT3742:
-              is_trial: false
-          MCT3742F3:
-              is_trial: false
-          MCT3742RN:
-              is_trial: false
-          MCT3742S:
-              is_trial: false
-          MCT3743:
-              is_trial: false
-          MCT3743F3:
-              is_trial: false
-          MCT3743RN:
-              is_trial: false
-          MCT3743S:
-              is_trial: false
-          MCT3744:
-              is_trial: false
-          MCT3744F3:
-              is_trial: false
-          MCT3744RN:
-              is_trial: false
-          MCT3744S:
-              is_trial: false
-          MCT3809:
-              is_trial: false
-          MCT3809RN:
-              is_trial: false
-          MCT3809F3:
-              is_trial: false
-          MCT3809F3RN:
-              is_trial: false
-          MCT3809S:
-              is_trial: false
-          MCT3810:
-              is_trial: false
-          MCT3810RN:
-              is_trial: false
-          MCT3810F3:
-              is_trial: false
-          MCT3810F3RN:
-              is_trial: false
-          MCT3810S:
-              is_trial: false
-          MCT3811:
-              is_trial: false
-          MCT3811RN:
-              is_trial: false
-          MCT3811F3:
-              is_trial: false
-          MCT3811F3RN:
-              is_trial: false
-          MCT3811S:
-              is_trial: false
-          MCT3812:
-              is_trial: false
-          MCT3812RN:
-              is_trial: false
-          MCT3812F3:
-              is_trial: false
-          MCT3812F3RN:
-              is_trial: false
-          MCT3812S:
-              is_trial: false
-          MCT3813:
-              is_trial: false
-          MCT3813RN:
-              is_trial: false
-          MCT3813F3:
-              is_trial: false
-          MCT3813F3RN:
-              is_trial: false
-          MCT3813S:
-              is_trial: false
-          MCT3814:
-              is_trial: false
-          MCT3814RN:
-              is_trial: false
-          MCT3814F3:
-              is_trial: false
-          MCT3814F3RN:
-              is_trial: false
-          MCT3815S:
-              is_trial: false
-          MCT3815:
-              is_trial: false
-          MCT3815RN:
-              is_trial: false
-          MCT3815F3:
-              is_trial: false
-          MCT3815F3RN:
-              is_trial: false
-          MCT3816:
-              is_trial: false
-          MCT3816RN:
-              is_trial: false
-          MCT3816F3:
-              is_trial: false
-          MCT3816F3RN:
-              is_trial: false
-          MCT3816S:
-              is_trial: false
-          MCT3817:
-              is_trial: false
-          MCT3817RN:
-              is_trial: false
-          MCT3817F3:
-              is_trial: false
-          MCT3817F3RN:
-              is_trial: false
-          MCT3817S:
-              is_trial: false
-          MCT3865:
-              is_trial: false
-          MCT3865RN:
-              is_trial: false
-          MCT3865F3:
-              is_trial: false
-          MCT3865F3RN:
-              is_trial: false
-          MCT3865S:
-              is_trial: false
-          MCT3866:
-              is_trial: false
-          MCT3866RN:
-              is_trial: false
-          MCT3866F3:
-              is_trial: false
-          MCT3866F3RN:
-              is_trial: false
-          MCT3866S:
-              is_trial: false
-          MCT3873:
-              is_trial: false
-          MCT3873RN:
-              is_trial: false
-          MCT3873F3:
-              is_trial: false
-          MCT3873F3RN:
-              is_trial: false
-          MCT3873S:
-              is_trial: false
-          MCT3874:
-              is_trial: false
-          MCT3874RN:
-              is_trial: false
-          MCT3874F3:
-              is_trial: false
-          MCT3874F3RN:
-              is_trial: false
-          MCT3874S:
-              is_trial: false
-          MCT3875:
-              is_trial: false
-          MCT3875RN:
-              is_trial: false
-          MCT3875F3:
-              is_trial: false
-          MCT3875F3RN:
-              is_trial: false
-          MCT3875S:
-              is_trial: false
-          MCT3876:
-              is_trial: false
-          MCT3876RN:
-              is_trial: false
-          MCT3876F3:
-              is_trial: false
-          MCT3876F3RN:
-              is_trial: false
-          MCT3876S:
-              is_trial: false
-          MCT3877:
-              is_trial: false
-          MCT3877RN:
-              is_trial: false
-          MCT3877F3:
-              is_trial: false
-          MCT3877F3RN:
-              is_trial: false
-          MCT3877S:
-              is_trial: false
-          MCT3878:
-              is_trial: false
-          MCT3878RN:
-              is_trial: false
-          MCT3878F3:
-              is_trial: false
-          MCT3878F3RN:
-              is_trial: false
-          MCT3878S:
-              is_trial: false
-          MCT3906:
-              is_trial: false
-          MCT3906RN:
-              is_trial: false
-          MCT3906F3:
-              is_trial: false
-          MCT3906F3RN:
-              is_trial: false
-          MCT3906S:
-              is_trial: false
-          MCT3907:
-              is_trial: false
-          MCT3907RN:
-              is_trial: false
-          MCT3907F3:
-              is_trial: false
-          MCT3907F3RN:
-              is_trial: false
-          MCT3907S:
-              is_trial: false
-          MCT3908:
-              is_trial: false
-          MCT3908RN:
-              is_trial: false
-          MCT3908F3:
-              is_trial: false
-          MCT3908F3RN:
-              is_trial: false
-          MCT3908S:
-              is_trial: false
-          MCT3909:
-              is_trial: false
-          MCT3909RN:
-              is_trial: false
-          MCT3909F3:
-              is_trial: false
-          MCT3909F3RN:
-              is_trial: false
-          MCT3909S:
-              is_trial: false
-          MCT3910:
-              is_trial: false
-          MCT3910RN:
-              is_trial: false
-          MCT3910F3:
-              is_trial: false
-          MCT3910F3RN:
-              is_trial: false
-          MCT3910S:
-              is_trial: false
-          MCT3911:
-              is_trial: false
-          MCT3911RN:
-              is_trial: false
-          MCT3911F3:
-              is_trial: false
-          MCT3911F3RN:
-              is_trial: false
-          MCT3911S:
-              is_trial: false
-          MCT3948:
-              is_trial: false
-          MW01459:
-              is_trial: false
-          MW01460:
-              is_trial: false
-          MW01461:
-              is_trial: false
-          MW01462:
-              is_trial: false
-          MW01737:
-              is_trial: false
-          MW01882:
-              is_trial: false
-          MW01891:
-              is_trial: false
-          MW01892MO:
-              is_trial: false
-          SER0496:
-              is_trial: true
-          SER0497:
-              is_trial: true
-          SER0569:
-              is_trial: true
-          SER0570:
-              is_trial: true
-          SER0574:
-              is_trial: true
+          - RH00798
+          - ESA0016
+          - MCT3319
+          - MCT3319F3
+          - MCT3319RN
+          - MCT3319S
+          - MCT3320
+          - MCT3320F3
+          - MCT3320RN
+          - MCT3320S
+          - MCT3321
+          - MCT3321F3
+          - MCT3321RN
+          - MCT3321S
+          - MCT3487
+          - MCT3487F3
+          - MCT3487RN
+          - MCT3487S
+          - MCT3488
+          - MCT3488F3
+          - MCT3488RN
+          - MCT3488S
+          - MCT3685
+          - MCT3685RN
+          - MCT3685F3
+          - MCT3685F3RN
+          - MCT3685S
+          - MCT3691
+          - MCT3691RN
+          - MCT3691F3
+          - MCT3691F3RN
+          - MCT3691S
+          - MCT3692
+          - MCT3692RN
+          - MCT3692F3
+          - MCT3692F3RN
+          - MCT3692S
+          - MCT3693
+          - MCT3693RN
+          - MCT3693F3
+          - MCT3693F3RN
+          - MCT3693S
+          - MCT3694
+          - MCT3694RN
+          - MCT3694F3
+          - MCT3694F3RN
+          - MCT3694S
+          - MCT3695
+          - MCT3695RN
+          - MCT3695F3
+          - MCT3695F3RN
+          - MCT3695S
+          - MCT3696
+          - MCT3696RN
+          - MCT3696F3
+          - MCT3696F3RN
+          - MCT3696S
+          - MCT3698
+          - MCT3698RN
+          - MCT3698F3
+          - MCT3698F3RN
+          - MCT3698S
+          - MCT3733
+          - MCT3733RN
+          - MCT3733F3
+          - MCT3733F3RN
+          - MCT3733S
+          - MCT3734
+          - MCT3734RN
+          - MCT3734F3
+          - MCT3734F3RN
+          - MCT3734S
+          - MCT3735
+          - MCT3735RN
+          - MCT3735F3
+          - MCT3735F3RN
+          - MCT3735S
+          - MCT3742
+          - MCT3742F3
+          - MCT3742RN
+          - MCT3742S
+          - MCT3743
+          - MCT3743F3
+          - MCT3743RN
+          - MCT3743S
+          - MCT3744
+          - MCT3744F3
+          - MCT3744RN
+          - MCT3744S
+          - MCT3809
+          - MCT3809RN
+          - MCT3809F3
+          - MCT3809F3RN
+          - MCT3809S
+          - MCT3810
+          - MCT3810RN
+          - MCT3810F3
+          - MCT3810F3RN
+          - MCT3810S
+          - MCT3811
+          - MCT3811RN
+          - MCT3811F3
+          - MCT3811F3RN
+          - MCT3811S
+          - MCT3812
+          - MCT3812RN
+          - MCT3812F3
+          - MCT3812F3RN
+          - MCT3812S
+          - MCT3813
+          - MCT3813RN
+          - MCT3813F3
+          - MCT3813F3RN
+          - MCT3813S
+          - MCT3814
+          - MCT3814RN
+          - MCT3814F3
+          - MCT3814F3RN
+          - MCT3815S
+          - MCT3815
+          - MCT3815RN
+          - MCT3815F3
+          - MCT3815F3RN
+          - MCT3816
+          - MCT3816RN
+          - MCT3816F3
+          - MCT3816F3RN
+          - MCT3816S
+          - MCT3817
+          - MCT3817RN
+          - MCT3817F3
+          - MCT3817F3RN
+          - MCT3817S
+          - MCT3865
+          - MCT3865RN
+          - MCT3865F3
+          - MCT3865F3RN
+          - MCT3865S
+          - MCT3866
+          - MCT3866RN
+          - MCT3866F3
+          - MCT3866F3RN
+          - MCT3866S
+          - MCT3873
+          - MCT3873RN
+          - MCT3873F3
+          - MCT3873F3RN
+          - MCT3873S
+          - MCT3874
+          - MCT3874RN
+          - MCT3874F3
+          - MCT3874F3RN
+          - MCT3874S
+          - MCT3875
+          - MCT3875RN
+          - MCT3875F3
+          - MCT3875F3RN
+          - MCT3875S
+          - MCT3876
+          - MCT3876RN
+          - MCT3876F3
+          - MCT3876F3RN
+          - MCT3876S
+          - MCT3877
+          - MCT3877RN
+          - MCT3877F3
+          - MCT3877F3RN
+          - MCT3877S
+          - MCT3878
+          - MCT3878RN
+          - MCT3878F3
+          - MCT3878F3RN
+          - MCT3878S
+          - MCT3906
+          - MCT3906RN
+          - MCT3906F3
+          - MCT3906F3RN
+          - MCT3906S
+          - MCT3907
+          - MCT3907RN
+          - MCT3907F3
+          - MCT3907F3RN
+          - MCT3907S
+          - MCT3908
+          - MCT3908RN
+          - MCT3908F3
+          - MCT3908F3RN
+          - MCT3908S
+          - MCT3909
+          - MCT3909RN
+          - MCT3909F3
+          - MCT3909F3RN
+          - MCT3909S
+          - MCT3910
+          - MCT3910RN
+          - MCT3910F3
+          - MCT3910F3RN
+          - MCT3910S
+          - MCT3911
+          - MCT3911RN
+          - MCT3911F3
+          - MCT3911F3RN
+          - MCT3911S
+          - MCT3948
+          - MW01459
+          - MW01460
+          - MW01461
+          - MW01462
+          - MW01737
+          - MW01882
+          - MW01891
+          - MW01892MO
+          - SER0496
+          - SER0497
+          - SER0569
+          - SER0570
+          - SER0574
 
       - name: cost_management
         use_valid_acc_num: true
@@ -464,18 +247,14 @@ objects:
 
       - name: smart_management
         skus:
-          SVC3124:
-              is_trial: false
-          RH00066:
-              is_trial: true
-          RH00065:
-              is_trial: true
-          RH00798:
-              is_trial: false
+          - SVC3124
+          - RH00066
+          - RH00065
+          - RH00798
 
       - name: internal
         use_is_internal: true
-        
+
       - name: rhel
         use_valid_acc_num: true
   kind: ConfigMap

--- a/configs/prod/bundles.yml
+++ b/configs/prod/bundles.yml
@@ -6,440 +6,223 @@ objects:
     bundles.yml: |
       - name: ansible
         skus:
-          RH00798:
-              is_trial: false
-          ESA0016:
-              is_trial: false
-          MCT3319:
-              is_trial: false
-          MCT3319F3:
-              is_trial: false
-          MCT3319RN:
-              is_trial: false
-          MCT3319S:
-              is_trial: false
-          MCT3320:
-              is_trial: false
-          MCT3320F3:
-              is_trial: false
-          MCT3320RN:
-              is_trial: false
-          MCT3320S:
-              is_trial: false
-          MCT3321:
-              is_trial: false
-          MCT3321F3:
-              is_trial: false
-          MCT3321RN:
-              is_trial: false
-          MCT3321S:
-              is_trial: false
-          MCT3487:
-              is_trial: false
-          MCT3487F3:
-              is_trial: false
-          MCT3487RN:
-              is_trial: false
-          MCT3487S:
-              is_trial: false
-          MCT3488:
-              is_trial: false
-          MCT3488F3:
-              is_trial: false
-          MCT3488RN:
-              is_trial: false
-          MCT3488S:
-              is_trial: false
-          MCT3685:
-              is_trial: false
-          MCT3685RN:
-              is_trial: false
-          MCT3685F3:
-              is_trial: false
-          MCT3685F3RN:
-              is_trial: false
-          MCT3685S:
-              is_trial: false
-          MCT3691:
-              is_trial: false
-          MCT3691RN:
-              is_trial: false
-          MCT3691F3:
-              is_trial: false
-          MCT3691F3RN:
-              is_trial: false
-          MCT3691S:
-              is_trial: false
-          MCT3692:
-              is_trial: false
-          MCT3692RN:
-              is_trial: false
-          MCT3692F3:
-              is_trial: false
-          MCT3692F3RN:
-              is_trial: false
-          MCT3692S:
-              is_trial: false
-          MCT3693:
-              is_trial: false
-          MCT3693RN:
-              is_trial: false
-          MCT3693F3:
-              is_trial: false
-          MCT3693F3RN:
-              is_trial: false
-          MCT3693S:
-              is_trial: false
-          MCT3694:
-              is_trial: false
-          MCT3694RN:
-              is_trial: false
-          MCT3694F3:
-              is_trial: false
-          MCT3694F3RN:
-              is_trial: false
-          MCT3694S:
-              is_trial: false
-          MCT3695:
-              is_trial: false
-          MCT3695RN:
-              is_trial: false
-          MCT3695F3:
-              is_trial: false
-          MCT3695F3RN:
-              is_trial: false
-          MCT3695S:
-              is_trial: false
-          MCT3696:
-              is_trial: false
-          MCT3696RN:
-              is_trial: false
-          MCT3696F3:
-              is_trial: false
-          MCT3696F3RN:
-              is_trial: false
-          MCT3696S:
-              is_trial: false
-          MCT3698:
-              is_trial: false
-          MCT3698RN:
-              is_trial: false
-          MCT3698F3:
-              is_trial: false
-          MCT3698F3RN:
-              is_trial: false
-          MCT3698S:
-              is_trial: false
-          MCT3733:
-              is_trial: false
-          MCT3733RN:
-              is_trial: false
-          MCT3733F3:
-              is_trial: false
-          MCT3733F3RN:
-              is_trial: false
-          MCT3733S:
-              is_trial: false
-          MCT3734:
-              is_trial: false
-          MCT3734RN:
-              is_trial: false
-          MCT3734F3:
-              is_trial: false
-          MCT3734F3RN:
-              is_trial: false
-          MCT3734S:
-              is_trial: false
-          MCT3735:
-              is_trial: false
-          MCT3735RN:
-              is_trial: false
-          MCT3735F3:
-              is_trial: false
-          MCT3735F3RN:
-              is_trial: false
-          MCT3735S:
-              is_trial: false
-          MCT3742:
-              is_trial: false
-          MCT3742F3:
-              is_trial: false
-          MCT3742RN:
-              is_trial: false
-          MCT3742S:
-              is_trial: false
-          MCT3743:
-              is_trial: false
-          MCT3743F3:
-              is_trial: false
-          MCT3743RN:
-              is_trial: false
-          MCT3743S:
-              is_trial: false
-          MCT3744:
-              is_trial: false
-          MCT3744F3:
-              is_trial: false
-          MCT3744RN:
-              is_trial: false
-          MCT3744S:
-              is_trial: false
-          MCT3809:
-              is_trial: false
-          MCT3809RN:
-              is_trial: false
-          MCT3809F3:
-              is_trial: false
-          MCT3809F3RN:
-              is_trial: false
-          MCT3809S:
-              is_trial: false
-          MCT3810:
-              is_trial: false
-          MCT3810RN:
-              is_trial: false
-          MCT3810F3:
-              is_trial: false
-          MCT3810F3RN:
-              is_trial: false
-          MCT3810S:
-              is_trial: false
-          MCT3811:
-              is_trial: false
-          MCT3811RN:
-              is_trial: false
-          MCT3811F3:
-              is_trial: false
-          MCT3811F3RN:
-              is_trial: false
-          MCT3811S:
-              is_trial: false
-          MCT3812:
-              is_trial: false
-          MCT3812RN:
-              is_trial: false
-          MCT3812F3:
-              is_trial: false
-          MCT3812F3RN:
-              is_trial: false
-          MCT3812S:
-              is_trial: false
-          MCT3813:
-              is_trial: false
-          MCT3813RN:
-              is_trial: false
-          MCT3813F3:
-              is_trial: false
-          MCT3813F3RN:
-              is_trial: false
-          MCT3813S:
-              is_trial: false
-          MCT3814:
-              is_trial: false
-          MCT3814RN:
-              is_trial: false
-          MCT3814F3:
-              is_trial: false
-          MCT3814F3RN:
-              is_trial: false
-          MCT3815S:
-              is_trial: false
-          MCT3815:
-              is_trial: false
-          MCT3815RN:
-              is_trial: false
-          MCT3815F3:
-              is_trial: false
-          MCT3815F3RN:
-              is_trial: false
-          MCT3816:
-              is_trial: false
-          MCT3816RN:
-              is_trial: false
-          MCT3816F3:
-              is_trial: false
-          MCT3816F3RN:
-              is_trial: false
-          MCT3816S:
-              is_trial: false
-          MCT3817:
-              is_trial: false
-          MCT3817RN:
-              is_trial: false
-          MCT3817F3:
-              is_trial: false
-          MCT3817F3RN:
-              is_trial: false
-          MCT3817S:
-              is_trial: false
-          MCT3865:
-              is_trial: false
-          MCT3865RN:
-              is_trial: false
-          MCT3865F3:
-              is_trial: false
-          MCT3865F3RN:
-              is_trial: false
-          MCT3865S:
-              is_trial: false
-          MCT3866:
-              is_trial: false
-          MCT3866RN:
-              is_trial: false
-          MCT3866F3:
-              is_trial: false
-          MCT3866F3RN:
-              is_trial: false
-          MCT3866S:
-              is_trial: false
-          MCT3873:
-              is_trial: false
-          MCT3873RN:
-              is_trial: false
-          MCT3873F3:
-              is_trial: false
-          MCT3873F3RN:
-              is_trial: false
-          MCT3873S:
-              is_trial: false
-          MCT3874:
-              is_trial: false
-          MCT3874RN:
-              is_trial: false
-          MCT3874F3:
-              is_trial: false
-          MCT3874F3RN:
-              is_trial: false
-          MCT3874S:
-              is_trial: false
-          MCT3875:
-              is_trial: false
-          MCT3875RN:
-              is_trial: false
-          MCT3875F3:
-              is_trial: false
-          MCT3875F3RN:
-              is_trial: false
-          MCT3875S:
-              is_trial: false
-          MCT3876:
-              is_trial: false
-          MCT3876RN:
-              is_trial: false
-          MCT3876F3:
-              is_trial: false
-          MCT3876F3RN:
-              is_trial: false
-          MCT3876S:
-              is_trial: false
-          MCT3877:
-              is_trial: false
-          MCT3877RN:
-              is_trial: false
-          MCT3877F3:
-              is_trial: false
-          MCT3877F3RN:
-              is_trial: false
-          MCT3877S:
-              is_trial: false
-          MCT3878:
-              is_trial: false
-          MCT3878RN:
-              is_trial: false
-          MCT3878F3:
-              is_trial: false
-          MCT3878F3RN:
-              is_trial: false
-          MCT3878S:
-              is_trial: false
-          MCT3906:
-              is_trial: false
-          MCT3906RN:
-              is_trial: false
-          MCT3906F3:
-              is_trial: false
-          MCT3906F3RN:
-              is_trial: false
-          MCT3906S:
-              is_trial: false
-          MCT3907:
-              is_trial: false
-          MCT3907RN:
-              is_trial: false
-          MCT3907F3:
-              is_trial: false
-          MCT3907F3RN:
-              is_trial: false
-          MCT3907S:
-              is_trial: false
-          MCT3908:
-              is_trial: false
-          MCT3908RN:
-              is_trial: false
-          MCT3908F3:
-              is_trial: false
-          MCT3908F3RN:
-              is_trial: false
-          MCT3908S:
-              is_trial: false
-          MCT3909:
-              is_trial: false
-          MCT3909RN:
-              is_trial: false
-          MCT3909F3:
-              is_trial: false
-          MCT3909F3RN:
-              is_trial: false
-          MCT3909S:
-              is_trial: false
-          MCT3910:
-              is_trial: false
-          MCT3910RN:
-              is_trial: false
-          MCT3910F3:
-              is_trial: false
-          MCT3910F3RN:
-              is_trial: false
-          MCT3910S:
-              is_trial: false
-          MCT3911:
-              is_trial: false
-          MCT3911RN:
-              is_trial: false
-          MCT3911F3:
-              is_trial: false
-          MCT3911F3RN:
-              is_trial: false
-          MCT3911S:
-              is_trial: false
-          MCT3948:
-              is_trial: false
-          MW01459:
-              is_trial: false
-          MW01460:
-              is_trial: false
-          MW01461:
-              is_trial: false
-          MW01462:
-              is_trial: false
-          MW01737:
-              is_trial: false
-          MW01882:
-              is_trial: false
-          MW01891:
-              is_trial: false
-          MW01892MO:
-              is_trial: false
-          SER0496:
-              is_trial: true
-          SER0497:
-              is_trial: true
-          SER0569:
-              is_trial: true
-          SER0570:
-              is_trial: true
-          SER0574:
-              is_trial: true
+          - RH00798
+          - ESA0016
+          - MCT3319
+          - MCT3319F3
+          - MCT3319RN
+          - MCT3319S
+          - MCT3320
+          - MCT3320F3
+          - MCT3320RN
+          - MCT3320S
+          - MCT3321
+          - MCT3321F3
+          - MCT3321RN
+          - MCT3321S
+          - MCT3487
+          - MCT3487F3
+          - MCT3487RN
+          - MCT3487S
+          - MCT3488
+          - MCT3488F3
+          - MCT3488RN
+          - MCT3488S
+          - MCT3685
+          - MCT3685RN
+          - MCT3685F3
+          - MCT3685F3RN
+          - MCT3685S
+          - MCT3691
+          - MCT3691RN
+          - MCT3691F3
+          - MCT3691F3RN
+          - MCT3691S
+          - MCT3692
+          - MCT3692RN
+          - MCT3692F3
+          - MCT3692F3RN
+          - MCT3692S
+          - MCT3693
+          - MCT3693RN
+          - MCT3693F3
+          - MCT3693F3RN
+          - MCT3693S
+          - MCT3694
+          - MCT3694RN
+          - MCT3694F3
+          - MCT3694F3RN
+          - MCT3694S
+          - MCT3695
+          - MCT3695RN
+          - MCT3695F3
+          - MCT3695F3RN
+          - MCT3695S
+          - MCT3696
+          - MCT3696RN
+          - MCT3696F3
+          - MCT3696F3RN
+          - MCT3696S
+          - MCT3698
+          - MCT3698RN
+          - MCT3698F3
+          - MCT3698F3RN
+          - MCT3698S
+          - MCT3733
+          - MCT3733RN
+          - MCT3733F3
+          - MCT3733F3RN
+          - MCT3733S
+          - MCT3734
+          - MCT3734RN
+          - MCT3734F3
+          - MCT3734F3RN
+          - MCT3734S
+          - MCT3735
+          - MCT3735RN
+          - MCT3735F3
+          - MCT3735F3RN
+          - MCT3735S
+          - MCT3742
+          - MCT3742F3
+          - MCT3742RN
+          - MCT3742S
+          - MCT3743
+          - MCT3743F3
+          - MCT3743RN
+          - MCT3743S
+          - MCT3744
+          - MCT3744F3
+          - MCT3744RN
+          - MCT3744S
+          - MCT3809
+          - MCT3809RN
+          - MCT3809F3
+          - MCT3809F3RN
+          - MCT3809S
+          - MCT3810
+          - MCT3810RN
+          - MCT3810F3
+          - MCT3810F3RN
+          - MCT3810S
+          - MCT3811
+          - MCT3811RN
+          - MCT3811F3
+          - MCT3811F3RN
+          - MCT3811S
+          - MCT3812
+          - MCT3812RN
+          - MCT3812F3
+          - MCT3812F3RN
+          - MCT3812S
+          - MCT3813
+          - MCT3813RN
+          - MCT3813F3
+          - MCT3813F3RN
+          - MCT3813S
+          - MCT3814
+          - MCT3814RN
+          - MCT3814F3
+          - MCT3814F3RN
+          - MCT3815S
+          - MCT3815
+          - MCT3815RN
+          - MCT3815F3
+          - MCT3815F3RN
+          - MCT3816
+          - MCT3816RN
+          - MCT3816F3
+          - MCT3816F3RN
+          - MCT3816S
+          - MCT3817
+          - MCT3817RN
+          - MCT3817F3
+          - MCT3817F3RN
+          - MCT3817S
+          - MCT3865
+          - MCT3865RN
+          - MCT3865F3
+          - MCT3865F3RN
+          - MCT3865S
+          - MCT3866
+          - MCT3866RN
+          - MCT3866F3
+          - MCT3866F3RN
+          - MCT3866S
+          - MCT3873
+          - MCT3873RN
+          - MCT3873F3
+          - MCT3873F3RN
+          - MCT3873S
+          - MCT3874
+          - MCT3874RN
+          - MCT3874F3
+          - MCT3874F3RN
+          - MCT3874S
+          - MCT3875
+          - MCT3875RN
+          - MCT3875F3
+          - MCT3875F3RN
+          - MCT3875S
+          - MCT3876
+          - MCT3876RN
+          - MCT3876F3
+          - MCT3876F3RN
+          - MCT3876S
+          - MCT3877
+          - MCT3877RN
+          - MCT3877F3
+          - MCT3877F3RN
+          - MCT3877S
+          - MCT3878
+          - MCT3878RN
+          - MCT3878F3
+          - MCT3878F3RN
+          - MCT3878S
+          - MCT3906
+          - MCT3906RN
+          - MCT3906F3
+          - MCT3906F3RN
+          - MCT3906S
+          - MCT3907
+          - MCT3907RN
+          - MCT3907F3
+          - MCT3907F3RN
+          - MCT3907S
+          - MCT3908
+          - MCT3908RN
+          - MCT3908F3
+          - MCT3908F3RN
+          - MCT3908S
+          - MCT3909
+          - MCT3909RN
+          - MCT3909F3
+          - MCT3909F3RN
+          - MCT3909S
+          - MCT3910
+          - MCT3910RN
+          - MCT3910F3
+          - MCT3910F3RN
+          - MCT3910S
+          - MCT3911
+          - MCT3911RN
+          - MCT3911F3
+          - MCT3911F3RN
+          - MCT3911S
+          - MCT3948
+          - MW01459
+          - MW01460
+          - MW01461
+          - MW01462
+          - MW01737
+          - MW01882
+          - MW01891
+          - MW01892MO
+          - SER0496
+          - SER0497
+          - SER0569
+          - SER0570
+          - SER0574
 
       - name: cost_management
         use_valid_acc_num: true
@@ -464,38 +247,28 @@ objects:
 
       - name: smart_management
         skus:
-          SVC3124:
-              is_trial: false
-          RH00066:
-              is_trial: true
-          RH00065:
-              is_trial: true
-          RH00798:
-              is_trial: false
+          - SVC3124
+          - RH00066
+          - RH00065
+          - RH00798
 
       - name: internal
         use_is_internal: true
-        
+
       - name: rhel
         use_valid_acc_num: true
 
       - name: rhods
         skus:
-          MCT4217MO:
-            is_trial: false
+          - MCT4217MO
 
       - name: rhoam
         skus:
-          MW01459:
-            is_trial: false
-          MW01460:
-            is_trial: false
-          MW0461:
-            is_trial: false
-          MW01462:
-            is_trial: false
-          MW01737:
-            is_trial: false
+          - MW01459
+          - MW01460
+          - MW0461
+          - MW01462
+          - MW01737
   kind: ConfigMap
   metadata:
     creationTimestamp: null

--- a/configs/stage/bundles.yml
+++ b/configs/stage/bundles.yml
@@ -6,440 +6,223 @@ objects:
     bundles.yml: |
       - name: ansible
         skus:
-          RH00798:
-              is_trial: false
-          ESA0016:
-              is_trial: false
-          MCT3319:
-              is_trial: false
-          MCT3319F3:
-              is_trial: false
-          MCT3319RN:
-              is_trial: false
-          MCT3319S:
-              is_trial: false
-          MCT3320:
-              is_trial: false
-          MCT3320F3:
-              is_trial: false
-          MCT3320RN:
-              is_trial: false
-          MCT3320S:
-              is_trial: false
-          MCT3321:
-              is_trial: false
-          MCT3321F3:
-              is_trial: false
-          MCT3321RN:
-              is_trial: false
-          MCT3321S:
-              is_trial: false
-          MCT3487:
-              is_trial: false
-          MCT3487F3:
-              is_trial: false
-          MCT3487RN:
-              is_trial: false
-          MCT3487S:
-              is_trial: false
-          MCT3488:
-              is_trial: false
-          MCT3488F3:
-              is_trial: false
-          MCT3488RN:
-              is_trial: false
-          MCT3488S:
-              is_trial: false
-          MCT3685:
-              is_trial: false
-          MCT3685RN:
-              is_trial: false
-          MCT3685F3:
-              is_trial: false
-          MCT3685F3RN:
-              is_trial: false
-          MCT3685S:
-              is_trial: false
-          MCT3691:
-              is_trial: false
-          MCT3691RN:
-              is_trial: false
-          MCT3691F3:
-              is_trial: false
-          MCT3691F3RN:
-              is_trial: false
-          MCT3691S:
-              is_trial: false
-          MCT3692:
-              is_trial: false
-          MCT3692RN:
-              is_trial: false
-          MCT3692F3:
-              is_trial: false
-          MCT3692F3RN:
-              is_trial: false
-          MCT3692S:
-              is_trial: false
-          MCT3693:
-              is_trial: false
-          MCT3693RN:
-              is_trial: false
-          MCT3693F3:
-              is_trial: false
-          MCT3693F3RN:
-              is_trial: false
-          MCT3693S:
-              is_trial: false
-          MCT3694:
-              is_trial: false
-          MCT3694RN:
-              is_trial: false
-          MCT3694F3:
-              is_trial: false
-          MCT3694F3RN:
-              is_trial: false
-          MCT3694S:
-              is_trial: false
-          MCT3695:
-              is_trial: false
-          MCT3695RN:
-              is_trial: false
-          MCT3695F3:
-              is_trial: false
-          MCT3695F3RN:
-              is_trial: false
-          MCT3695S:
-              is_trial: false
-          MCT3696:
-              is_trial: false
-          MCT3696RN:
-              is_trial: false
-          MCT3696F3:
-              is_trial: false
-          MCT3696F3RN:
-              is_trial: false
-          MCT3696S:
-              is_trial: false
-          MCT3698:
-              is_trial: false
-          MCT3698RN:
-              is_trial: false
-          MCT3698F3:
-              is_trial: false
-          MCT3698F3RN:
-              is_trial: false
-          MCT3698S:
-              is_trial: false
-          MCT3733:
-              is_trial: false
-          MCT3733RN:
-              is_trial: false
-          MCT3733F3:
-              is_trial: false
-          MCT3733F3RN:
-              is_trial: false
-          MCT3733S:
-              is_trial: false
-          MCT3734:
-              is_trial: false
-          MCT3734RN:
-              is_trial: false
-          MCT3734F3:
-              is_trial: false
-          MCT3734F3RN:
-              is_trial: false
-          MCT3734S:
-              is_trial: false
-          MCT3735:
-              is_trial: false
-          MCT3735RN:
-              is_trial: false
-          MCT3735F3:
-              is_trial: false
-          MCT3735F3RN:
-              is_trial: false
-          MCT3735S:
-              is_trial: false
-          MCT3742:
-              is_trial: false
-          MCT3742F3:
-              is_trial: false
-          MCT3742RN:
-              is_trial: false
-          MCT3742S:
-              is_trial: false
-          MCT3743:
-              is_trial: false
-          MCT3743F3:
-              is_trial: false
-          MCT3743RN:
-              is_trial: false
-          MCT3743S:
-              is_trial: false
-          MCT3744:
-              is_trial: false
-          MCT3744F3:
-              is_trial: false
-          MCT3744RN:
-              is_trial: false
-          MCT3744S:
-              is_trial: false
-          MCT3809:
-              is_trial: false
-          MCT3809RN:
-              is_trial: false
-          MCT3809F3:
-              is_trial: false
-          MCT3809F3RN:
-              is_trial: false
-          MCT3809S:
-              is_trial: false
-          MCT3810:
-              is_trial: false
-          MCT3810RN:
-              is_trial: false
-          MCT3810F3:
-              is_trial: false
-          MCT3810F3RN:
-              is_trial: false
-          MCT3810S:
-              is_trial: false
-          MCT3811:
-              is_trial: false
-          MCT3811RN:
-              is_trial: false
-          MCT3811F3:
-              is_trial: false
-          MCT3811F3RN:
-              is_trial: false
-          MCT3811S:
-              is_trial: false
-          MCT3812:
-              is_trial: false
-          MCT3812RN:
-              is_trial: false
-          MCT3812F3:
-              is_trial: false
-          MCT3812F3RN:
-              is_trial: false
-          MCT3812S:
-              is_trial: false
-          MCT3813:
-              is_trial: false
-          MCT3813RN:
-              is_trial: false
-          MCT3813F3:
-              is_trial: false
-          MCT3813F3RN:
-              is_trial: false
-          MCT3813S:
-              is_trial: false
-          MCT3814:
-              is_trial: false
-          MCT3814RN:
-              is_trial: false
-          MCT3814F3:
-              is_trial: false
-          MCT3814F3RN:
-              is_trial: false
-          MCT3815S:
-              is_trial: false
-          MCT3815:
-              is_trial: false
-          MCT3815RN:
-              is_trial: false
-          MCT3815F3:
-              is_trial: false
-          MCT3815F3RN:
-              is_trial: false
-          MCT3816:
-              is_trial: false
-          MCT3816RN:
-              is_trial: false
-          MCT3816F3:
-              is_trial: false
-          MCT3816F3RN:
-              is_trial: false
-          MCT3816S:
-              is_trial: false
-          MCT3817:
-              is_trial: false
-          MCT3817RN:
-              is_trial: false
-          MCT3817F3:
-              is_trial: false
-          MCT3817F3RN:
-              is_trial: false
-          MCT3817S:
-              is_trial: false
-          MCT3865:
-              is_trial: false
-          MCT3865RN:
-              is_trial: false
-          MCT3865F3:
-              is_trial: false
-          MCT3865F3RN:
-              is_trial: false
-          MCT3865S:
-              is_trial: false
-          MCT3866:
-              is_trial: false
-          MCT3866RN:
-              is_trial: false
-          MCT3866F3:
-              is_trial: false
-          MCT3866F3RN:
-              is_trial: false
-          MCT3866S:
-              is_trial: false
-          MCT3873:
-              is_trial: false
-          MCT3873RN:
-              is_trial: false
-          MCT3873F3:
-              is_trial: false
-          MCT3873F3RN:
-              is_trial: false
-          MCT3873S:
-              is_trial: false
-          MCT3874:
-              is_trial: false
-          MCT3874RN:
-              is_trial: false
-          MCT3874F3:
-              is_trial: false
-          MCT3874F3RN:
-              is_trial: false
-          MCT3874S:
-              is_trial: false
-          MCT3875:
-              is_trial: false
-          MCT3875RN:
-              is_trial: false
-          MCT3875F3:
-              is_trial: false
-          MCT3875F3RN:
-              is_trial: false
-          MCT3875S:
-              is_trial: false
-          MCT3876:
-              is_trial: false
-          MCT3876RN:
-              is_trial: false
-          MCT3876F3:
-              is_trial: false
-          MCT3876F3RN:
-              is_trial: false
-          MCT3876S:
-              is_trial: false
-          MCT3877:
-              is_trial: false
-          MCT3877RN:
-              is_trial: false
-          MCT3877F3:
-              is_trial: false
-          MCT3877F3RN:
-              is_trial: false
-          MCT3877S:
-              is_trial: false
-          MCT3878:
-              is_trial: false
-          MCT3878RN:
-              is_trial: false
-          MCT3878F3:
-              is_trial: false
-          MCT3878F3RN:
-              is_trial: false
-          MCT3878S:
-              is_trial: false
-          MCT3906:
-              is_trial: false
-          MCT3906RN:
-              is_trial: false
-          MCT3906F3:
-              is_trial: false
-          MCT3906F3RN:
-              is_trial: false
-          MCT3906S:
-              is_trial: false
-          MCT3907:
-              is_trial: false
-          MCT3907RN:
-              is_trial: false
-          MCT3907F3:
-              is_trial: false
-          MCT3907F3RN:
-              is_trial: false
-          MCT3907S:
-              is_trial: false
-          MCT3908:
-              is_trial: false
-          MCT3908RN:
-              is_trial: false
-          MCT3908F3:
-              is_trial: false
-          MCT3908F3RN:
-              is_trial: false
-          MCT3908S:
-              is_trial: false
-          MCT3909:
-              is_trial: false
-          MCT3909RN:
-              is_trial: false
-          MCT3909F3:
-              is_trial: false
-          MCT3909F3RN:
-              is_trial: false
-          MCT3909S:
-              is_trial: false
-          MCT3910:
-              is_trial: false
-          MCT3910RN:
-              is_trial: false
-          MCT3910F3:
-              is_trial: false
-          MCT3910F3RN:
-              is_trial: false
-          MCT3910S:
-              is_trial: false
-          MCT3911:
-              is_trial: false
-          MCT3911RN:
-              is_trial: false
-          MCT3911F3:
-              is_trial: false
-          MCT3911F3RN:
-              is_trial: false
-          MCT3911S:
-              is_trial: false
-          MCT3948:
-              is_trial: false
-          MW01459:
-              is_trial: false
-          MW01460:
-              is_trial: false
-          MW01461:
-              is_trial: false
-          MW01462:
-              is_trial: false
-          MW01737:
-              is_trial: false
-          MW01882:
-              is_trial: false
-          MW01891:
-              is_trial: false
-          MW01892MO:
-              is_trial: false
-          SER0496:
-              is_trial: true
-          SER0497:
-              is_trial: true
-          SER0569:
-              is_trial: true
-          SER0570:
-              is_trial: true
-          SER0574:
-              is_trial: true
+          - RH00798
+          - ESA0016
+          - MCT3319
+          - MCT3319F3
+          - MCT3319RN
+          - MCT3319S
+          - MCT3320
+          - MCT3320F3
+          - MCT3320RN
+          - MCT3320S
+          - MCT3321
+          - MCT3321F3
+          - MCT3321RN
+          - MCT3321S
+          - MCT3487
+          - MCT3487F3
+          - MCT3487RN
+          - MCT3487S
+          - MCT3488
+          - MCT3488F3
+          - MCT3488RN
+          - MCT3488S
+          - MCT3685
+          - MCT3685RN
+          - MCT3685F3
+          - MCT3685F3RN
+          - MCT3685S
+          - MCT3691
+          - MCT3691RN
+          - MCT3691F3
+          - MCT3691F3RN
+          - MCT3691S
+          - MCT3692
+          - MCT3692RN
+          - MCT3692F3
+          - MCT3692F3RN
+          - MCT3692S
+          - MCT3693
+          - MCT3693RN
+          - MCT3693F3
+          - MCT3693F3RN
+          - MCT3693S
+          - MCT3694
+          - MCT3694RN
+          - MCT3694F3
+          - MCT3694F3RN
+          - MCT3694S
+          - MCT3695
+          - MCT3695RN
+          - MCT3695F3
+          - MCT3695F3RN
+          - MCT3695S
+          - MCT3696
+          - MCT3696RN
+          - MCT3696F3
+          - MCT3696F3RN
+          - MCT3696S
+          - MCT3698
+          - MCT3698RN
+          - MCT3698F3
+          - MCT3698F3RN
+          - MCT3698S
+          - MCT3733
+          - MCT3733RN
+          - MCT3733F3
+          - MCT3733F3RN
+          - MCT3733S
+          - MCT3734
+          - MCT3734RN
+          - MCT3734F3
+          - MCT3734F3RN
+          - MCT3734S
+          - MCT3735
+          - MCT3735RN
+          - MCT3735F3
+          - MCT3735F3RN
+          - MCT3735S
+          - MCT3742
+          - MCT3742F3
+          - MCT3742RN
+          - MCT3742S
+          - MCT3743
+          - MCT3743F3
+          - MCT3743RN
+          - MCT3743S
+          - MCT3744
+          - MCT3744F3
+          - MCT3744RN
+          - MCT3744S
+          - MCT3809
+          - MCT3809RN
+          - MCT3809F3
+          - MCT3809F3RN
+          - MCT3809S
+          - MCT3810
+          - MCT3810RN
+          - MCT3810F3
+          - MCT3810F3RN
+          - MCT3810S
+          - MCT3811
+          - MCT3811RN
+          - MCT3811F3
+          - MCT3811F3RN
+          - MCT3811S
+          - MCT3812
+          - MCT3812RN
+          - MCT3812F3
+          - MCT3812F3RN
+          - MCT3812S
+          - MCT3813
+          - MCT3813RN
+          - MCT3813F3
+          - MCT3813F3RN
+          - MCT3813S
+          - MCT3814
+          - MCT3814RN
+          - MCT3814F3
+          - MCT3814F3RN
+          - MCT3815S
+          - MCT3815
+          - MCT3815RN
+          - MCT3815F3
+          - MCT3815F3RN
+          - MCT3816
+          - MCT3816RN
+          - MCT3816F3
+          - MCT3816F3RN
+          - MCT3816S
+          - MCT3817
+          - MCT3817RN
+          - MCT3817F3
+          - MCT3817F3RN
+          - MCT3817S
+          - MCT3865
+          - MCT3865RN
+          - MCT3865F3
+          - MCT3865F3RN
+          - MCT3865S
+          - MCT3866
+          - MCT3866RN
+          - MCT3866F3
+          - MCT3866F3RN
+          - MCT3866S
+          - MCT3873
+          - MCT3873RN
+          - MCT3873F3
+          - MCT3873F3RN
+          - MCT3873S
+          - MCT3874
+          - MCT3874RN
+          - MCT3874F3
+          - MCT3874F3RN
+          - MCT3874S
+          - MCT3875
+          - MCT3875RN
+          - MCT3875F3
+          - MCT3875F3RN
+          - MCT3875S
+          - MCT3876
+          - MCT3876RN
+          - MCT3876F3
+          - MCT3876F3RN
+          - MCT3876S
+          - MCT3877
+          - MCT3877RN
+          - MCT3877F3
+          - MCT3877F3RN
+          - MCT3877S
+          - MCT3878
+          - MCT3878RN
+          - MCT3878F3
+          - MCT3878F3RN
+          - MCT3878S
+          - MCT3906
+          - MCT3906RN
+          - MCT3906F3
+          - MCT3906F3RN
+          - MCT3906S
+          - MCT3907
+          - MCT3907RN
+          - MCT3907F3
+          - MCT3907F3RN
+          - MCT3907S
+          - MCT3908
+          - MCT3908RN
+          - MCT3908F3
+          - MCT3908F3RN
+          - MCT3908S
+          - MCT3909
+          - MCT3909RN
+          - MCT3909F3
+          - MCT3909F3RN
+          - MCT3909S
+          - MCT3910
+          - MCT3910RN
+          - MCT3910F3
+          - MCT3910F3RN
+          - MCT3910S
+          - MCT3911
+          - MCT3911RN
+          - MCT3911F3
+          - MCT3911F3RN
+          - MCT3911S
+          - MCT3948
+          - MW01459
+          - MW01460
+          - MW01461
+          - MW01462
+          - MW01737
+          - MW01882
+          - MW01891
+          - MW01892MO
+          - SER0496
+          - SER0497
+          - SER0569
+          - SER0570
+          - SER0574
 
       - name: cost_management
         use_valid_acc_num: true
@@ -464,38 +247,28 @@ objects:
 
       - name: smart_management
         skus:
-          SVC3124:
-              is_trial: false
-          RH00066:
-              is_trial: true
-          RH00065:
-              is_trial: true
-          RH00798:
-              is_trial: false
+          - SVC3124
+          - RH00066
+          - RH00065
+          - RH00798
 
       - name: internal
         use_is_internal: true
-        
+
       - name: rhel
         use_valid_acc_num: true
 
       - name: rhods
         skus:
-          MCT4217MO:
-            is_trial: false
+          - MCT4217MO
 
       - name: rhoam
         skus:
-          MW01459:
-            is_trial: false
-          MW01460:
-            is_trial: false
-          MW0461:
-            is_trial: false
-          MW01462:
-            is_trial: false
-          MW01737:
-            is_trial: false
+          - MW01459
+          - MW01460
+          - MW0461
+          - MW01462
+          - MW01737
   kind: ConfigMap
   metadata:
     creationTimestamp: null


### PR DESCRIPTION
We no longer need the `is_trial` flag since this the logic of determining `is_trial`
was pushed off to the subscriptions API, and we get that returned to us in the payload
now [1].

[1] https://github.com/RedHatInsights/entitlements-api-go/blob/master/controllers/subscriptions.go#L191