### PR TITLE
Add Ansible's Monthly On-Demand SKU

### DIFF
--- a/configs/prod/bundles.yml
+++ b/configs/prod/bundles.yml
@@ -210,6 +210,7 @@ objects:
           - MCT3911F3RN
           - MCT3911S
           - MCT3948
+          - MCT4384MO
           - SER0496
           - SER0497
           - SER0569


### PR DESCRIPTION
Customers purchasing via Azure are awarded the SKU I have added.  They need access to Automation Hub to "do Ansible things" so this one should be included in their access bundle! I'm getting an Ansible PM to check the bundle and add any further changes, I'm submitting this one to handle support ticket 03302246.