### PR TITLE
Grant MCT4698/4699/4700 and their F3 SKUs access to Ansible services on HCC

### DIFF
--- a/configs/prod/bundles.yml
+++ b/configs/prod/bundles.yml
@@ -191,6 +191,12 @@ objects:
           - MCT4635F3
           - MCT4636
           - MCT4636F3
+          - MCT4698
+          - MCT4698F3
+          - MCT4699
+          - MCT4699F3
+          - MCT4700
+          - MCT4700F3
           - MW02049
           - MW02577
           - MW02577F3

--- a/configs/stage/bundles.yml
+++ b/configs/stage/bundles.yml
@@ -191,6 +191,12 @@ objects:
           - MCT4635F3
           - MCT4636
           - MCT4636F3
+          - MCT4698
+          - MCT4698F3
+          - MCT4699
+          - MCT4699F3
+          - MCT4700
+          - MCT4700F3
           - MW02049
           - MW02577
           - MW02577F3


### PR DESCRIPTION
Grant MCT4698/4699/4700 and their F3 SKUs access to Ansible services on HCC.
This is part of the work of June Ansible SKU Validation. These have been confirmed with Ansible BU.
More information in this Jira ticket: https://issues.redhat.com/browse/ENTQE-5446