### PR TITLE
Grant MCT4701 access to Ansible services on HCC

### DIFF
--- a/configs/prod/bundles.yml
+++ b/configs/prod/bundles.yml
@@ -197,6 +197,7 @@ objects:
           - MCT4699F3
           - MCT4700
           - MCT4700F3
+          - MCT4701
           - MW02049
           - MW02577
           - MW02577F3

--- a/configs/stage/bundles.yml
+++ b/configs/stage/bundles.yml
@@ -197,6 +197,7 @@ objects:
           - MCT4699F3
           - MCT4700
           - MCT4700F3
+          - MCT4701
           - MW02049
           - MW02577
           - MW02577F3


### PR DESCRIPTION
Grant MCT4701 access to Ansible services on HCC.
This is part of the work of July Ansible SKU Validation. These have been confirmed with Ansible BU.
More information in this Jira ticket: https://issues.redhat.com/browse/ENTQE-5569