### PR TITLE
Grant a couple of AAP subscriptions access to Ansible services on HCC

### DIFF
--- a/configs/prod/bundles.yml
+++ b/configs/prod/bundles.yml
@@ -94,10 +94,12 @@ objects:
           - MCT3873RN
           - MCT3873F3
           - MCT3874
+          - MCR3875
           - MCT3876
           - MCT3876RN
           - MCT3876F3
           - MCT3876S
+          - MCT3877
           - MCT3878
           - MCT3948
           - MCT3948F3
@@ -198,6 +200,10 @@ objects:
           - MCT4700
           - MCT4700F3
           - MCT4701
+          - MCT4702
+          - MCT4702F3
+          - MCT4703
+          - MCT4703F3
           - MW02049
           - MW02577
           - MW02577F3

--- a/configs/stage/bundles.yml
+++ b/configs/stage/bundles.yml
@@ -94,10 +94,12 @@ objects:
           - MCT3873RN
           - MCT3873F3
           - MCT3874
+          - MCT3875
           - MCT3876
           - MCT3876RN
           - MCT3876F3
           - MCT3876S
+          - MCT3877
           - MCT3878
           - MCT3948
           - MCT3948F3
@@ -198,6 +200,10 @@ objects:
           - MCT4700
           - MCT4700F3
           - MCT4701
+          - MCT4702
+          - MCT4702F3
+          - MCT4703
+          - MCT4703F3
           - MW02049
           - MW02577
           - MW02577F3


### PR DESCRIPTION
Grant MCT3875, MCT3877, MCT4702, MCT4702F3, MCT4703 and MCT4703F3 access to Ansible services on HCC.
This is part of the outcome of CY24 August Ansible SKU Validation. These have been confirmed with Ansible BU.
More information in this Jira ticket: https://issues.redhat.com/browse/ENTQE-5679