### PR TITLE
[RHCLOUD-41491] [STAGE] Remove deprecated Entitlements bundles 

### DIFF
--- a/configs/stage/bundles.yml
+++ b/configs/stage/bundles.yml
@@ -249,21 +249,6 @@ objects:
       - name: user_preferences
         use_valid_org_id: true
 
-      - name: smart_management
-        skus:
-          - SVC3124
-          - RH00066
-          - RH00065
-          - RH00798
-          - RH00031
-          - RH00031F3
-          - RH00032
-          - RH00032F3
-          - RH00039
-          - RH00039F3
-          - RH00040
-          - RH00040F3
-
       - name: internal
         use_is_internal: true
 
@@ -271,40 +256,6 @@ objects:
         skus:
           - MCT4217MO
           - MCT4163
-
-      - name: rhoam
-        skus:
-          - MW01459
-          - MW01460
-          - MW01461
-          - MW01462
-          - MW01737
-          - MW01458
-          - MW01458MO
-          - MW01459
-          - MW01459MO
-          - MW01460
-          - MW01460MO
-          - MW01461
-          - MW01461MO
-          - MW01462
-          - MW01462MO
-          - MW01737
-          - MW01738MO
-          - MW01845MO
-          - MW01846
-
-      - name: rhosak
-        skus:
-          - MW01882
-          - MW01891
-          - MW01892MO
-          - MW01891
-          - MW01892MO
-          - MW01894
-          - MW01896MO
-          - MW01893
-          - MW01895MO
 
       - name: openshift
         skus:


### PR DESCRIPTION
Related JIRA link: https://issues.redhat.com/browse/RHCLOUD-41491

Based on JIRA ticket description: 

Remove rhoam/rhosak/smart_management from entitlements bundles 
