### PR TITLE
Trying to fix entitlements stage with adding back the smart management SKUs

### DIFF
--- a/configs/stage/bundles.yml
+++ b/configs/stage/bundles.yml
@@ -249,6 +249,21 @@ objects:
       - name: user_preferences
         use_valid_org_id: true
 
+      - name: smart_management
+        skus:
+          - SVC3124
+          - RH00066
+          - RH00065
+          - RH00798
+          - RH00031
+          - RH00031F3
+          - RH00032
+          - RH00032F3
+          - RH00039
+          - RH00039F3
+          - RH00040
+          - RH00040F3
+
       - name: internal
         use_is_internal: true
 


### PR DESCRIPTION
Related slack thread: https://redhat-internal.slack.com/archives/C022YV4E0NA/p1756330891787499

It seems that entitlements stage is having some issues, and it may be related to the fact that smart management skus were deprecated in a previous PR so testing it out here