### PR TITLE
Restore Deprecated Bundles from Prod

### DIFF
--- a/configs/prod/bundles.yml
+++ b/configs/prod/bundles.yml
@@ -252,6 +252,15 @@ objects:
       - name: openshift
         use_valid_org_id: false
 
+      - name: smart_management
+        skus:
+          - SVC3124
+          - RH00066
+          - RH00065
+          - RH00798
+          - RH00067
+          - RH00068
+
       - name: internal
         use_is_internal: true
 
@@ -261,6 +270,20 @@ objects:
       - name: rhods
         skus:
           - MCT4217MO
+
+      - name: rhoam
+        skus:
+          - MW01459
+          - MW01460
+          - MW01461
+          - MW01462
+          - MW01737
+
+      - name: rhosak
+        skus: 
+          - MW01882
+          - MW01891
+          - MW01892MO
 
       - name: acs
         skus:


### PR DESCRIPTION
related slack thread: https://redhat-internal.slack.com/archives/C08BQP8PGT1/p1756909861095399

One of the prod pods are crashlooping because of the deprecated bundles being removed

