### PR TITLE
Add a bunch of AAP SKUs that are effective since Q2CY26 to the ansible subscription feature

### DIFF
--- a/configs/prod/bundles.yml
+++ b/configs/prod/bundles.yml
@@ -108,8 +108,6 @@ objects:
           - MCT3948
           - MCT3948F3
           - MCT4249
-          - SER0496
-          - SER0497
           - MCT4164
           - MCT4165
           - MCT4164F3
@@ -238,6 +236,20 @@ objects:
           - MCT4817
           - MCT4817F3
           - MCT4817F5
+          - MCT4992
+          - MCT4993
+          - MCT4994
+          - MCT4995
+          - MCT4996
+          - MCT4997
+          - MCT4998
+          - MCT4999
+          - MCT5000
+          - MCT5001
+          - MCT5026
+          - MCT5134
+          - MCT5135
+          - MCT5196
           - MW02049
           - MW02577
           - MW02577F3
@@ -245,6 +257,8 @@ objects:
           - MW02581F3
           - RC1257407
           - ES0113909
+          - SER0496
+          - SER0497
       
       - name: cost_management
         use_valid_org_id: true

--- a/configs/stage/bundles.yml
+++ b/configs/stage/bundles.yml
@@ -96,8 +96,6 @@ objects:
           - MCT4631
           - MCT3691F3RN
           - MCT4597F3
-          - SER0496
-          - SER0497
           - ESA0016
           - MCT4755F3
           - MCT4212F3
@@ -245,6 +243,22 @@ objects:
           - MCT4714F5
           - MCT4166F3
           - MCT3993F3
+          - MCT4992
+          - MCT4993
+          - MCT4994
+          - MCT4995
+          - MCT4996
+          - MCT4997
+          - MCT4998
+          - MCT4999
+          - MCT5000
+          - MCT5001
+          - MCT5026
+          - MCT5134
+          - MCT5135
+          - MCT5196
+          - SER0496
+          - SER0497
       
       - name: cost_management
         use_valid_org_id: true


### PR DESCRIPTION
Add a bunch of AAP SKUs that are effective since Q2CY26 to the ansible subscription feature. These have been confirmed with Ansible BU.
More information in this Jira ticket: https://redhat.atlassian.net/browse/AAP-71100